### PR TITLE
Fix clap error when run with debug asserts

### DIFF
--- a/clang-tidy-sarif/src/bin.rs
+++ b/clang-tidy-sarif/src/bin.rs
@@ -98,6 +98,7 @@ fn main() -> Result<()> {
     .arg(
       Arg::new("output")
         .help("output file; writes to stdout if none is given")
+        .allow_invalid_utf8(true)
         .short('o')
         .long("output")
         .takes_value(true),

--- a/clippy-sarif/src/bin.rs
+++ b/clippy-sarif/src/bin.rs
@@ -96,11 +96,13 @@ fn main() -> Result<()> {
         .arg(
             Arg::new("input")
                 .help("input file; reads from stdin if none is given")
+                .allow_invalid_utf8(true)
                 .takes_value(true),
         )
         .arg(
             Arg::new("output")
                 .help("output file; writes to stdout if none is given")
+                .allow_invalid_utf8(true)
                 .short('o')
                 .long("output")
                 .takes_value(true),

--- a/hadolint-sarif/src/bin.rs
+++ b/hadolint-sarif/src/bin.rs
@@ -95,11 +95,13 @@ fn main() -> Result<()> {
     .arg(
       Arg::new("input")
         .help("input file; reads from stdin if none is given")
+        .allow_invalid_utf8(true)
         .takes_value(true),
     )
     .arg(
       Arg::new("output")
         .help("output file; writes to stdout if none is given")
+        .allow_invalid_utf8(true)
         .short('o')
         .long("output")
         .takes_value(true),

--- a/sarif-fmt/src/bin.rs
+++ b/sarif-fmt/src/bin.rs
@@ -786,6 +786,7 @@ fn main() -> Result<()> {
     .arg(
       Arg::new("input")
         .help("input file; reads from stdin if none is given")
+        .allow_invalid_utf8(true)
         .takes_value(true),
     )
     .get_matches();

--- a/shellcheck-sarif/src/bin.rs
+++ b/shellcheck-sarif/src/bin.rs
@@ -95,11 +95,13 @@ fn main() -> Result<()> {
     .arg(
       Arg::new("input")
         .help("input file; reads from stdin if none is given")
+        .allow_invalid_utf8(true)
         .takes_value(true),
     )
     .arg(
       Arg::new("output")
         .help("output file; writes to stdout if none is given")
+        .allow_invalid_utf8(true)
         .short('o')
         .long("output")
         .takes_value(true),


### PR DESCRIPTION
Clap reports errors like this when run with debug asserts:
Arg::allow_invalid_utf8` with `_os` lookups at

This adds `.allow_invalid_utf8(true)` to those arguments.