### PR TITLE
Extend `clippy-sarif` to re-emit the original formatted error messages

### DIFF
--- a/clippy-sarif/src/bin.rs
+++ b/clippy-sarif/src/bin.rs
@@ -105,6 +105,12 @@ fn main() -> Result<()> {
                 .long("output")
                 .takes_value(true),
         )
+        .arg(
+            Arg::new("emit_rendered_diagnostics")
+                .help("emit the original error message")
+                .long("emit-rendered-diagnostics")
+                .takes_value(false),
+        )
         .get_matches();
 
   let read = match matches.value_of_os("input").map(Path::new) {
@@ -119,5 +125,9 @@ fn main() -> Result<()> {
   };
   let writer = BufWriter::new(write);
 
-  serde_sarif::converters::clippy::parse_to_writer(reader, writer)
+  serde_sarif::converters::clippy::parse_to_writer(
+    reader,
+    writer,
+    matches.is_present("emit_rendered_diagnostics"),
+  )
 }


### PR DESCRIPTION
I tried implementing my suggestion from https://github.com/psastras/sarif-rs/discussions/171

The code adds a new flag to `clippy-sarif` which prints the original rendered diagnostics if they are available in the JSON messages.
The handling looks a bit ugly due to the multiple necessary checks. For one, messages need to be deduplicated, as the same warning can appear for different targets, e.g., lib+docs.
The same message can also appear for different targets, which is why the whole `CompilerMessage` is deduplicated, not just the rendered diagnostic.
The one additional `Result` layer for the `filter_map` is necessary, to correctly handle errors when writing to stderr, for example if it is redirected to `/dev/full`.

I would be happy to hear some feedback if this is an acceptable way to implement the feature.

---

clippy original error message:

```
warning: unused variable: `x`
   --> clippy-sarif/src/bin.rs:120:7
    |
120 |   let x = ();
    |       ^ help: if this is intentional, prefix it with an underscore: `_x`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: `clippy-sarif` (bin "clippy-sarif" test) generated 1 warning
warning: `clippy-sarif` (bin "clippy-sarif") generated 1 warning (1 duplicate)
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
```

`cargo clippy --all-targets --all-features --message-format=json-diagnostic-rendered-ansi 2>/dev/null | clippy-sarif --emit-rendered-diagnostics >./results.sarif`:

```
warning: unused variable: `x`
   --> clippy-sarif/src/bin.rs:120:7
    |
120 |   let x = ();
    |       ^ help: if this is intentional, prefix it with an underscore: `_x`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: 1 warning emitted
```