### PR TITLE
Prefer `serde_json::from_str` over `serde_json::from_reader`

### DIFF
--- a/sarif-fmt/src/bin.rs
+++ b/sarif-fmt/src/bin.rs
@@ -144,8 +144,10 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::usize;
 
-fn process<R: BufRead>(reader: R) -> Result<sarif::Sarif> {
-  let s: sarif::Sarif = serde_json::from_reader(reader)?;
+fn process<R: BufRead>(mut reader: R) -> Result<sarif::Sarif> {
+  let mut data = String::new();
+  reader.read_to_string(&mut data)?;
+  let s: sarif::Sarif = serde_json::from_str(&data)?;
   Ok(s)
 }
 

--- a/serde-sarif/src/converters/hadolint.rs
+++ b/serde-sarif/src/converters/hadolint.rs
@@ -90,12 +90,14 @@ impl TryFrom<&HadolintResult> for sarif::Region {
   }
 }
 
-fn process<R: BufRead>(reader: R) -> Result<sarif::Sarif> {
+fn process<R: BufRead>(mut reader: R) -> Result<sarif::Sarif> {
+  let mut data = String::new();
+  reader.read_to_string(&mut data)?;
   let mut results = vec![];
   let mut map = HashMap::new();
   let mut rules = vec![];
 
-  let hadolint_results: Vec<HadolintResult> = serde_json::from_reader(reader)?;
+  let hadolint_results: Vec<HadolintResult> = serde_json::from_str(&data)?;
   hadolint_results
     .iter()
     .try_for_each(|result| -> Result<()> {

--- a/serde-sarif/src/converters/shellcheck.rs
+++ b/serde-sarif/src/converters/shellcheck.rs
@@ -135,13 +135,14 @@ impl TryFrom<&ShellcheckResult> for sarif::Region {
   }
 }
 
-fn process<R: BufRead>(reader: R) -> Result<sarif::Sarif> {
+fn process<R: BufRead>(mut reader: R) -> Result<sarif::Sarif> {
+  let mut data = String::new();
+  reader.read_to_string(&mut data)?;
   let mut results = vec![];
   let mut map = HashMap::new();
   let mut rules = vec![];
 
-  let shellcheck_results: Vec<ShellcheckResult> =
-    serde_json::from_reader(reader)?;
+  let shellcheck_results: Vec<ShellcheckResult> = serde_json::from_str(&data)?;
   shellcheck_results
     .iter()
     .try_for_each(|result| -> Result<()> {


### PR DESCRIPTION
`serde_json` is optimized for `&str` deserialization. So much so, that it is faster to read everything into memory once, and then deserialize from `&str`.
    
This commit replaces all `from_reader` with `from_str`.