### PR TITLE
Format generated sarif.rs using prettyplease instead of rustfmt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "prettyplease"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e07e3a46d0771a8a06b5f4441527802830b43e679ba12f44960f48dd4c6803"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +488,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "derive_builder",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",

--- a/serde-sarif/Cargo.toml
+++ b/serde-sarif/Cargo.toml
@@ -39,6 +39,7 @@ version-sync = "0.9"
 
 [build-dependencies]
 anyhow = "1.0.57"
+prettyplease = "0.1.10"
 proc-macro2 = "1.0.37"
 quote = "1.0.18"
 schemafy_lib = "0.6.0"

--- a/serde-sarif/build.rs
+++ b/serde-sarif/build.rs
@@ -1,36 +1,18 @@
-use quote::ToTokens;
 use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
-use std::process::Command;
-use std::process::Stdio;
 
 use anyhow::Result;
 use schemafy_lib::Expander;
 use schemafy_lib::Schema;
 
-// Run `rustfmt` in the input text
-fn reformat(text: impl std::fmt::Display) -> Result<String> {
-  let mut rustfmt = Command::new("rustfmt")
-    .stdin(Stdio::piped())
-    .stdout(Stdio::piped())
-    .spawn()?;
-  write!(rustfmt.stdin.take().unwrap(), "{}", text)?;
-  let output = rustfmt.wait_with_output()?;
-  let stdout = String::from_utf8(output.stdout)?;
-
-  Ok(stdout)
-}
-
 // Add additional items to the generated sarif.rs file
 // Currently adds: derive(Builder) to each struct
 // and apprpriate use statements at the top of the file
 // todo: this (and other parts) need a refactor and tests
-fn process_token_stream(
-  input: proc_macro2::TokenStream,
-) -> proc_macro2::TokenStream {
+fn process_token_stream(input: proc_macro2::TokenStream) -> syn::File {
   let mut ast: syn::File = syn::parse2(input).unwrap();
 
   // add use directives to top of the file
@@ -92,7 +74,7 @@ fn process_token_stream(
     }
   });
 
-  ast.into_token_stream()
+  ast
 }
 
 fn main() -> Result<()> {
@@ -105,12 +87,12 @@ fn main() -> Result<()> {
   let schema: Schema = serde_json::from_str(&json)?;
   let path_str = path.to_str().unwrap();
   let mut expander = Expander::new(Some("Sarif"), path_str, &schema);
-  let token_stream = process_token_stream(expander.expand(&schema));
+  let generated = process_token_stream(expander.expand(&schema));
 
   // Write the struct to the $OUT_DIR/sarif.rs file.
   let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
   let mut file = File::create(out_path.join("sarif.rs"))?;
-  file.write_all(reformat(token_stream.to_string())?.as_bytes())?;
+  file.write_all(prettyplease::unparse(&generated).as_bytes())?;
 
   Ok(())
 }


### PR DESCRIPTION
This avoids relying on the user's host to have a suitable version of rustfmt installed for the right toolchain.

Previously, the build script failed like this on my machine:

```console
error: failed to run custom build command for `serde-sarif v0.3.0`

Caused by:
  process didn't exit successfully: `target/debug/build/serde-sarif-c0dd8a6b8827cf78/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-changed=src/schema.json

  --- stderr
  error: 'rustfmt' is not installed for the toolchain '1.58.0-x86_64-unknown-linux-gnu'
  To install, run `rustup component add rustfmt --toolchain 1.58.0-x86_64-unknown-linux-gnu`
  Error: Broken pipe (os error 32)
```