### PR TITLE
support cargo-binstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,19 @@ $ warning: using `Option.and_then(|x| Some(y))`, which is more succinctly expres
 
 ## Install
 
-Each CLI may be installed via `cargo` or directly downloaded from the
+Each CLI may be installed via `cargo`, [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) or directly downloaded from the
 corresponding Github release.
 
 ### Cargo
 
 ```shell
 cargo install <cli_name> # ex. cargo install sarif-fmt
+```
+
+### Cargo-binstall
+
+```shell
+cargo binstall <cli_name> # ex. cargo binstall sarif-fmt
 ```
 
 ### Github Releases

--- a/clang-tidy-sarif/Cargo.toml
+++ b/clang-tidy-sarif/Cargo.toml
@@ -26,3 +26,7 @@ clap = "3.2.22"
 
 [dev-dependencies]
 version-sync = "0.9"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }"
+pkg-fmt = "bin"

--- a/clang-tidy-sarif/README.md
+++ b/clang-tidy-sarif/README.md
@@ -1,5 +1,7 @@
 [![Workflow Status](https://github.com/psastras/sarif-rs/workflows/main/badge.svg)](https://github.com/psastras/sarif-rs/actions?query=workflow%3A%22main%22)
 
+# clang-tidy-sarif
+
 This crate provides a command line tool to convert `clang-tidy` diagnostic
 output into SARIF.
 
@@ -20,6 +22,12 @@ the official website:
 
 ```shell
 cargo install clang-tidy-sarif
+```
+
+via [cargo-binstall](https://github.com/cargo-bins/cargo-binstall)
+
+```shell
+cargo binstall clang-tidy-sarif
 ```
 
 or downloaded directly from Github Releases

--- a/clippy-sarif/Cargo.toml
+++ b/clippy-sarif/Cargo.toml
@@ -26,3 +26,7 @@ clap = "3.2.22"
 
 [dev-dependencies]
 version-sync = "0.9"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }"
+pkg-fmt = "bin"

--- a/clippy-sarif/README.md
+++ b/clippy-sarif/README.md
@@ -24,6 +24,12 @@ the official website:
 cargo install clippy-sarif
 ```
 
+via [cargo-binstall](https://github.com/cargo-bins/cargo-binstall)
+
+```shell
+cargo binstall clippy-sarif
+```
+
 or downloaded directly from Github Releases
 
 ```shell

--- a/hadolint-sarif/Cargo.toml
+++ b/hadolint-sarif/Cargo.toml
@@ -26,3 +26,7 @@ clap = "3.2.22"
 
 [dev-dependencies]
 version-sync = "0.9"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }"
+pkg-fmt = "bin"

--- a/hadolint-sarif/README.md
+++ b/hadolint-sarif/README.md
@@ -24,6 +24,12 @@ the official website:
 cargo install hadolint-sarif
 ```
 
+via [cargo-binstall](https://github.com/cargo-bins/cargo-binstall)
+
+```shell
+cargo binstall hadolint-sarif
+```
+
 or downloaded directly from Github Releases
 
 ```shell

--- a/sarif-fmt/Cargo.toml
+++ b/sarif-fmt/Cargo.toml
@@ -30,3 +30,7 @@ clap = "3.2.22"
 duct = "0.13.5"
 duct_sh = "0.13.5"
 version-sync = "0.9"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }"
+pkg-fmt = "bin"

--- a/sarif-fmt/README.md
+++ b/sarif-fmt/README.md
@@ -20,6 +20,12 @@ the official website:
 cargo install sarif-fmt
 ```
 
+via [cargo-binstall](https://github.com/cargo-bins/cargo-binstall)
+
+```shell
+cargo binstall sarif-fmt
+```
+
 or downloaded directly from Github Releases
 
 ```shell

--- a/shellcheck-sarif/Cargo.toml
+++ b/shellcheck-sarif/Cargo.toml
@@ -26,3 +26,7 @@ clap = "3.2.22"
 
 [dev-dependencies]
 version-sync = "0.9"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }"
+pkg-fmt = "bin"

--- a/shellcheck-sarif/README.md
+++ b/shellcheck-sarif/README.md
@@ -24,6 +24,12 @@ the official website:
 cargo install shellcheck-sarif
 ```
 
+via [cargo-binstall](https://github.com/cargo-bins/cargo-binstall)
+
+```shell
+cargo binstall shellcheck-sarif
+```
+
 or downloaded directly from Github Releases
 
 ```shell


### PR DESCRIPTION
This additional metadata should add support for [cargo-binstall](https://github.com/cargo-bins/cargo-binstall).
Using `cargo binstall [crate]` instead of `cargo install crate` allows for faster installs since we can just download the binaries.
This helps reduce CI run time if a crate is not cached.

### Example workflow
```yml
on: [pull_request]

jobs:
clippy:
    name: Clippy
    runs-on: ubuntu-latest
    continue-on-error: true
    steps:
      - uses: actions/checkout@v2
      - uses: actions-rs/toolchain@v1
        with:
          profile: minimal
          toolchain: stable
          override: true
      - run: rustup component add clippy
      - uses: Swatinem/rust-cache@v1
      - name: Install cargo-binstall
        run: wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-gnu.tgz -O - | tar -xz -C $HOME/.cargo/bin  
      - run: cargo binstall sarif-fmt clippy-sarif && chmod +x -R $HOME/.cargo/bin
      - run: cargo clippy --all-targets --all-features --message-format=json |
          clippy-sarif | tee results.sarif | sarif-fmt
      - name: Upload SARIF file
        uses: github/codeql-action/upload-sarif@v1
        with:
          sarif_file: results.sarif
```



_**note:** for some reason the release artifacts don't have the +x attribute. Is this a limitation of GitHub since the binaries are not packed in an archive?_