### PR TITLE
feat: clang-tidy: collect "note" items into relatedLocations

### DIFF
--- a/sarif-fmt/src/bin.rs
+++ b/sarif-fmt/src/bin.rs
@@ -692,7 +692,7 @@ fn to_writer_pretty(sarif: &sarif::Sarif) -> Result<()> {
 
         if let Some(locations) = result.related_locations.as_ref() {
           locations.iter().for_each(|location| {
-            if let Some((file_id, range)) = location
+            if let Some((file_id, range, message)) = location
               .physical_location
               .as_ref()
               .and_then(|physical_location| {
@@ -707,7 +707,14 @@ fn to_writer_pretty(sarif: &sarif::Sarif) -> Result<()> {
                             if let (Some(range_start), Some(range_end)) =
                               get_byte_range(file_id, &files, region)
                             {
-                              Some((file_id, range_start..range_end))
+                              Some((
+                                file_id,
+                                range_start..range_end,
+                                location
+                                  .message
+                                  .as_ref()
+                                  .and_then(|x| x.text.clone()),
+                              ))
                             } else {
                               None
                             }
@@ -718,7 +725,10 @@ fn to_writer_pretty(sarif: &sarif::Sarif) -> Result<()> {
                 )
               })
             {
-              diagnostic.labels.push(Label::secondary(file_id, range));
+              diagnostic.labels.push(
+                Label::secondary(file_id, range)
+                  .with_message(message.unwrap_or("".to_string())),
+              );
             }
           });
         }

--- a/sarif-fmt/tests/clang-tidy-test.rs
+++ b/sarif-fmt/tests/clang-tidy-test.rs
@@ -78,5 +78,22 @@ fn test_clang_tidy() -> Result<()> {
   assert!(output.contains("cpp.cpp:4:10"));
   assert!(output.contains("return atoi(num);"));
 
+  assert!(output.contains("warning: Array access (from variable 'str') results in a null pointer dereference [clang-analyzer-core.NullDereference]"));
+  assert!(output.contains("cpp.cpp:8:10"));
+  assert!(output.contains("return str[0];"));
+  // 1st note for the above warning
+  assert!(output.contains("cpp.cpp:12:25"));
+  assert!(output.contains("return get_first_char(nullptr);"));
+  assert!(output.contains("Passing null pointer value via 1st parameter 'str'"));
+  // 2nd note, same line of code
+  assert!(output.contains("cpp.cpp:12:10"));
+  assert!(output.contains("Calling 'get_first_char'"));
+  // 3rd note, same line of code as the original warning
+  assert!(output.contains("cpp.cpp:8:10"));
+  assert!(output.contains("------- Array access (from variable 'str') results in a null pointer dereference"));
+
+  assert!(output.contains("calling 'system' uses a command processor"));
+  assert!(output.contains("cpp.cpp:16:3"));
+
   Ok(())
 }

--- a/sarif-fmt/tests/data/cpp.cpp
+++ b/sarif-fmt/tests/data/cpp.cpp
@@ -4,6 +4,14 @@ int string_to_int(const char *num) {
   return atoi(num);
 }
 
+static int get_first_char(const char* str) {
+  return str[0];
+}
+
+int test_note() {
+  return get_first_char(nullptr);
+}
+
 void ls() {
   system("ls");
 }

--- a/serde-sarif/src/converters/clang_tidy.rs
+++ b/serde-sarif/src/converters/clang_tidy.rs
@@ -55,61 +55,95 @@ impl TryFrom<&ClangTidyResult> for sarif::Location {
   fn try_from(result: &ClangTidyResult) -> Result<Self, Self::Error> {
     let artifact_location: sarif::ArtifactLocation = result.try_into()?;
     let region: sarif::Region = result.try_into()?;
-    Ok(
-      sarif::LocationBuilder::default()
-        .physical_location(
-          sarif::PhysicalLocationBuilder::default()
-            .artifact_location(artifact_location)
-            .region(region)
-            .build()?,
-        )
+    let mut builder = sarif::LocationBuilder::default();
+    builder.physical_location(
+      sarif::PhysicalLocationBuilder::default()
+        .artifact_location(artifact_location)
+        .region(region)
         .build()?,
-    )
+    );
+    // Notes are converted to 'location' items with the message stored along with the location.
+    // For other types of items (error, warning, info), the message will be stored inside the
+    // 'result', so we skip it here.
+    if result.level == "note" {
+      builder.message::<sarif::Message>((&result.message).try_into()?);
+    }
+    Ok(builder.build()?)
   }
+}
+
+fn parse_clang_tidy_line(
+  line: Result<String, std::io::Error>,
+) -> Option<ClangTidyResult> {
+  let re = Regex::new(
+    r#"^(?P<file>[\w/\.\- ]+):(?P<line>\d+):(?P<column>\d+):\s+(?P<level>error|warning|info|note):\s+(?P<message>.+)(?:\s+(?P<rules>\[[\w\-,\.]+\]))?$"#,
+  ).unwrap();
+  let line = line.unwrap();
+  let caps = re.captures(&line);
+  if let Some(caps) = caps {
+    if let Some(message) = caps.name("message") {
+      return Some(ClangTidyResult {
+        file: caps.name("file").map(|f| f.as_str().into()),
+        line: caps
+          .name("line")
+          .and_then(|f| f.as_str().parse::<i64>().ok()),
+        column: caps
+          .name("column")
+          .and_then(|f| f.as_str().parse::<i64>().ok()),
+        level: caps
+          .name("level")
+          .map_or_else(|| "info".into(), |f| f.as_str().into()),
+        message: message.as_str().into(),
+        rules: caps
+          .name("rules")
+          .map_or_else(|| "".into(), |f| f.as_str().into()),
+      });
+    }
+  }
+  None
 }
 
 fn process<R: BufRead>(reader: R) -> Result<sarif::Sarif> {
   let mut results = vec![];
-  let re = Regex::new(
-    r#"^(?P<file>[\w/\.\- ]+):(?P<line>\d+):(?P<column>\d+):\s+(?P<level>error|warning|info):\s+(?P<message>.+)\s+(?P<rules>\[[\w\-,\.]+\])$"#,
-  )?;
-  reader
+  // Create an iterator over all the ClangTidyResult items
+  let mut clang_tidy_result_iter = reader
     .lines()
     .into_iter()
-    .try_for_each(|line| -> Result<()> {
-      let line = line.unwrap();
-      let caps = re.captures(&line);
-      if let Some(caps) = caps {
-        if let Some(message) = caps.name("message") {
-          let result = ClangTidyResult {
-            file: caps.name("file").map(|f| f.as_str().into()),
-            line: caps
-              .name("line")
-              .and_then(|f| f.as_str().parse::<i64>().ok()),
-            column: caps
-              .name("column")
-              .and_then(|f| f.as_str().parse::<i64>().ok()),
-            level: caps
-              .name("level")
-              .map_or_else(|| "info".into(), |f| f.as_str().into()),
-            message: message.as_str().into(),
-            rules: caps
-              .name("rules")
-              .map_or_else(|| "".into(), |f| f.as_str().into()),
-          };
-          let location: sarif::Location = (&result).try_into()?;
-          let message = format!("{} {}", result.message, result.rules);
-          results.push(
-            sarif::ResultBuilder::default()
-              .message::<sarif::Message>((&message).try_into()?)
-              .locations(vec![location])
-              .level(result.level)
-              .build()?,
-          );
+    .filter_map(parse_clang_tidy_line)
+    .peekable();
+
+  while let Some(result) = clang_tidy_result_iter.next() {
+    let location: sarif::Location = (&result).try_into()?;
+    let mut related_locations = vec![];
+    let message = format!("{} {}", result.message, result.rules);
+
+    // Since clang-tidy emits "note" items which have to be folded into
+    // the previous error/warning/info items, look ahead at the next items
+    // and collect all the "notes".
+    while let Some(next_result) = clang_tidy_result_iter.peek() {
+      match next_result.level.as_str() {
+        "note" => {
+          let note_location: sarif::Location = (next_result).try_into()?;
+          related_locations.push(note_location);
+          // Since we got the next result via .peek(), advance the iterator
+          clang_tidy_result_iter.next();
+        }
+        _ => {
+          // Not a note, back to the outer loop
+          break;
         }
       }
-      Ok(())
-    })?;
+    }
+    let mut builder = sarif::ResultBuilder::default();
+    builder
+      .message::<sarif::Message>((&message).try_into()?)
+      .locations(vec![location])
+      .level(result.level);
+    if !related_locations.is_empty() {
+      builder.related_locations(related_locations);
+    }
+    results.push(builder.build()?);
+  }
 
   let tool_component: sarif::ToolComponent =
     sarif::ToolComponentBuilder::default()

--- a/serde-sarif/src/sarif.rs
+++ b/serde-sarif/src/sarif.rs
@@ -231,6 +231,11 @@ pub enum BuilderError {
     #[from]
     source: ResultBuilderError,
   },
+  #[error(transparent)]
+  MessageBuilderError {
+    #[from]
+    source: MessageBuilderError,
+  },
 }
 
 // Note that due to the blanket implementation in core, TryFrom<AsRef<String>>


### PR DESCRIPTION
This PR adds parsing of clang-tidy "note" items. Since notes follow the error/warning/info items, iteration logic becomes a bit more complex. I have tried to keep it readable, but not sure how idiomatic the code is.

I've also updated sarif-fmt to print the optional `message` fields of relatedLocations and extended the existing test case to cover this feature.

<details>
<summary>clang-tidy test output</summary>

```
warning: 'atoi' used to convert a string to an integer value, but function will not report conversion errors; consider using 'strtol' instead [cert-err34-c] 
  ┌─ /Users/ivan/p/sarif-rs/sarif-fmt/tests/data/cpp.cpp:4:10
  │
4 │   return atoi(num);
  │          ^^^^^^^^^^

warning: Array access (from variable 'str') results in a null pointer dereference [clang-analyzer-core.NullDereference] 
   ┌─ /Users/ivan/p/sarif-rs/sarif-fmt/tests/data/cpp.cpp:8:10
   │
 8 │   return str[0];
   │          ^^^^^^^
   │
   ┌─ /Users/ivan/p/sarif-rs/sarif-fmt/tests/data/cpp.cpp:12:25
   │
12 │   return get_first_char(nullptr);
   │                         --------- Passing null pointer value via 1st parameter 'str'
   │
   ┌─ /Users/ivan/p/sarif-rs/sarif-fmt/tests/data/cpp.cpp:12:10
   │
12 │   return get_first_char(nullptr);
   │          ------------------------ Calling 'get_first_char'
   │
   ┌─ /Users/ivan/p/sarif-rs/sarif-fmt/tests/data/cpp.cpp:8:10
   │
 8 │   return str[0];
   │          ------- Array access (from variable 'str') results in a null pointer dereference

warning: calling 'system' uses a command processor [cert-env33-c] 
   ┌─ /Users/ivan/p/sarif-rs/sarif-fmt/tests/data/cpp.cpp:16:3
   │
16 │   system("ls");
   │   ^^^^^^^^^^^^^

warning: 3 warnings emitted
```
</details>

Closes https://github.com/psastras/sarif-rs/issues/346
