### PR TITLE
shellcheck: add helpUri field to reportingDescriptor

### DIFF
--- a/serde-sarif/src/converters/shellcheck.rs
+++ b/serde-sarif/src/converters/shellcheck.rs
@@ -156,6 +156,10 @@ fn process<R: BufRead>(mut reader: R) -> Result<sarif::Sarif> {
             .short_description::<sarif::MultiformatMessageString>(
               (&format!("SC{}", result.code)).try_into()?,
             )
+            .help_uri(&format!(
+              "https://www.shellcheck.net/wiki/SC{}",
+              result.code
+            ))
             .full_description::<sarif::MultiformatMessageString>(
               (&format!(
                 "For more information: https://www.shellcheck.net/wiki/SC{}",


### PR DESCRIPTION
The Sarif 2.1.0 schema specifies reportingDescriptor has a helpUri property that is "A URI where the primary documentation for the report can be found."