### PR TITLE
Document example of installing on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Using `curl`,
 curl -sSL https://github.com/psastras/sarif-rs/releases/download/shellcheck-sarif-latest/shellcheck-sarif-x86_64-unknown-linux-gnu -o shellcheck-sarif
 ```
 
+### Fedora Linux
+
+```shell
+sudo dnf install <cli_name> # ex. cargo binstall sarif-fmt
+```
+
 ## Documentation
 
 See each subproject for more detailed information:


### PR DESCRIPTION
Document the way how to get sarif tools using `dnf` on Fedora Linux.

e.g `sudo dnf install sarif-fmt`

---

Fedora Packages:

* [clang-tidy-sarif](https://src.fedoraproject.org/rpms/rust-clang-tidy-sarif)
* [clippy-sarif](https://src.fedoraproject.org/rpms/rust-clippy-sarif)
* [hadolint-sarif](https://src.fedoraproject.org/rpms/rust-hadolint-sarif)
* [shellcheck-sarif](https://src.fedoraproject.org/rpms/rust-shellcheck-sarif)
* [sarif-fmt](https://src.fedoraproject.org/rpms/rust-sarif-fmt)
* [serde-sarif](https://src.fedoraproject.org/rpms/rust-serde-sarif)