### PR TITLE
add missing `clang-tidy-sarif` command in example

### DIFF
--- a/clang-tidy-sarif/README.md
+++ b/clang-tidy-sarif/README.md
@@ -93,7 +93,7 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v1
       - run: cargo install clang-tidy-sarif sarif-fmt
-      - run: clang-tidy -checks=cert-* -warnings-as-errors=* main.cpp -- | tee
+      - run: clang-tidy -checks=cert-* -warnings-as-errors=* main.cpp -- | clang-tidy-sarif | tee
           results.sarif | sarif-fmt
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v1


### PR DESCRIPTION
The example was missing the `clang-tidy-sarif` command between `clang-tidy` and `tee`.
This pull-request adds the missing command.