### PR TITLE
Use clang-tidy check name for `ruleId`

### DIFF
--- a/sarif-fmt/tests/clang-tidy-test.rs
+++ b/sarif-fmt/tests/clang-tidy-test.rs
@@ -63,7 +63,7 @@ fn test_clang_tidy() -> Result<()> {
     .full_env(&env_map)
     .read()?;
 
-  assert!(output.contains("warning: Array access (from variable 'str') results in a null pointer dereference [clang-analyzer-core.NullDereference]"));
+  assert!(output.contains("warning: Array access (from variable 'str') results in a null pointer dereference"));
   assert!(output.contains("cpp.cpp:8:10"));
   assert!(output.contains("return str[0];"));
   // 1st note for the above error


### PR DESCRIPTION
The SARIF specification requires that either `ruleId` or `rule.id` are set for a `result` object.

[§3.27.5 ruleId property](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790893)
> Direct producers SHALL emit either or both of ruleId and rule.id.

Currently, the output of `clang-tidy-sarif` sets neither.

This PR uses the first of the emitted Clang-Tidy check names to set the `ruleId` property.
The check names are also removed from the `message` property.