### PR TITLE
feat: add feature flag to enable fallback setters for builder

### DIFF
--- a/serde-sarif/Cargo.toml
+++ b/serde-sarif/Cargo.toml
@@ -25,6 +25,7 @@ clippy-converters = ["cargo_metadata", "regex", "anyhow"]
 hadolint-converters = ["anyhow"]
 shellcheck-converters = ["anyhow"]
 clang-tidy-converters = ["regex", "anyhow"]
+opt-builder = []
 
 [dependencies]
 anyhow = { version = "1.0.97", optional = true }

--- a/serde-sarif/README.md
+++ b/serde-sarif/README.md
@@ -80,4 +80,10 @@ serde-sarif = { version = "*", features = ["clippy-converters"] }
 - **shellcheck-converters** Provides conversions between shellcheck and SARIF
   types
 
+### Other
+
+- **opt-builder** Enables 
+  [`TypedBuilder`](https://docs.rs/typed-builder/latest/typed_builder/derive.TypedBuilder.html#customization-with-attributes)s
+  fallback setters for easier conditional building
+
 License: MIT

--- a/serde-sarif/build.rs
+++ b/serde-sarif/build.rs
@@ -115,9 +115,15 @@ fn process_token_stream(input: proc_macro2::TokenStream) -> syn::File {
       (&mut s.fields).into_iter().for_each(|ref mut field| {
         if let syn::Type::Path(typepath) = &field.ty {
           if path_is_option(&typepath.path) {
+            #[cfg(not(feature = "opt-builder"))]
             field.attrs.push(syn::parse_quote! {
               #[builder(setter(strip_option), default)]
-            })
+            });
+
+            #[cfg(feature = "opt-builder")]
+            field.attrs.push(syn::parse_quote! {
+              #[builder(setter(strip_option(fallback_prefix = "opt_")), default)]
+            });
           } else if path_is_vec(&typepath.path) {
             field.attrs.push(syn::parse_quote! {
               #[builder(default)]

--- a/serde-sarif/src/lib.rs
+++ b/serde-sarif/src/lib.rs
@@ -72,6 +72,12 @@
 //! - **clippy-converters** Provides conversions between Clippy and SARIF types
 //! - **hadolint-converters** Provides conversions between hadolint and SARIF types
 //! - **shellcheck-converters** Provides conversions between shellcheck and SARIF types
+//!
+//! ### Other
+//!
+//! - **opt-builder** Enables
+//!   [`TypedBuilder`](typed_builder::TypedBuilder)
+//!   fallback setters for easier conditional building
 
 pub mod converters;
 pub mod sarif;


### PR DESCRIPTION
Migration to the [typed_builder](https://docs.rs/typed-builder/latest/typed_builder/derive.TypedBuilder.html)  in v0.6.0 made a builder interface much more concise to use by removing the need to perform redundant error checking and unwraps, but made it much harder to do conditional building of sarif structures. 

Basic example of this can be found in the code for a clippy converter ([taken from here](https://github.com/psastras/sarif-rs/blob/09b2f6a0883443596ca5b9c95fb53d0c9a6a203c/serde-sarif/src/converters/clippy.rs#L134))
```
          let rule = if let Some(help_uri) = help_uri {
            rule.help_uri(help_uri).build()
          } else {
            rule.build()
          };
```

Every call to a setter method on a builder consumes `self` and returns a new builder with a different generics set. Because of it if any of the fields need to be set conditionally it will require a different "match arm" for every combination of said fields. In this example it's only one field, but with more fields it spirals out of control really fast (2^n fast to be exact).

This change enables the "fallback methods" from [typed_builder](https://docs.rs/typed-builder/latest/typed_builder/derive.TypedBuilder.html#customization-with-attributes). This allows to pass the `Option` directly to the setter.

This is a backwards compatible change, but because it effectively doubles the amount of setter methods on a builder (and, arguably, pollutes the namespace a bit) this change is hidden behind a feature flag.

@psastras, feel free to request changes for the fallback method naming (prefix vs suffix and it's value), name of the feature flag and the need for it in the first place if you find them lacking.