### PR TITLE
fix: compile clang-tidy regex once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,9 +308,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "os_pipe"
@@ -473,6 +473,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
+ "once_cell",
  "prettyplease",
  "proc-macro2",
  "quote",

--- a/serde-sarif/Cargo.toml
+++ b/serde-sarif/Cargo.toml
@@ -24,7 +24,7 @@ default = []
 clippy-converters = ["cargo_metadata", "regex", "anyhow"]
 hadolint-converters = ["anyhow"]
 shellcheck-converters = ["anyhow"]
-clang-tidy-converters = ["regex", "anyhow"]
+clang-tidy-converters = ["regex", "anyhow", "once_cell"]
 opt-builder = []
 
 [dependencies]
@@ -37,6 +37,7 @@ strum = "0.27"
 strum_macros = "0.27"
 thiserror = "2.0.12"
 typed-builder = "0.21.0"
+once_cell = { version = "1.21.3", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9"

--- a/serde-sarif/src/converters/clang_tidy.rs
+++ b/serde-sarif/src/converters/clang_tidy.rs
@@ -1,5 +1,6 @@
 use crate::sarif::{self};
 use anyhow::Result;
+use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
@@ -80,11 +81,13 @@ impl TryFrom<&ClangTidyResult> for sarif::Location {
 fn parse_clang_tidy_line(
   line: Result<String, std::io::Error>,
 ) -> Option<ClangTidyResult> {
-  let re = Regex::new(
+  static RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
     r"^(?P<file>([a-zA-Z]:|)[\w/\.\- \\]+):(?P<line>\d+):(?P<column>\d+):\s+(?P<level>error|warning|info|note):\s+(?P<message>.+?)(?:\s+\[(?P<rules>[^\]]+)\])?$"
-  ).unwrap();
+  ).unwrap()
+  });
   let line = line.unwrap();
-  let caps = re.captures(&line);
+  let caps = RE.captures(&line);
   if let Some(caps) = caps {
     if let Some(message) = caps.name("message") {
       return Some(ClangTidyResult {


### PR DESCRIPTION
Avoids recompiling regex used to parse clang-tidy output as per recommendation in [regex docs](https://docs.rs/regex/latest/regex/#avoid-re-compiling-regexes-especially-in-a-loop). Closes #839 

Here are flamegraphs of running `clang-tidy-sarif` on 13k loc clang-tidy output before
![old](https://github.com/user-attachments/assets/903815f2-17c5-452f-9933-a9c316cefef4)

and after the change
![new](https://github.com/user-attachments/assets/c5e8e4d9-1254-459f-bfd2-50cce6734e79)
