### PR TITLE
doc(hadolint-sarif): fix download url

### DIFF
--- a/hadolint-sarif/README.md
+++ b/hadolint-sarif/README.md
@@ -34,7 +34,7 @@ or downloaded directly from Github Releases
 
 ```shell
 # make sure to adjust the target and version (you may also want to pin to a specific version)
-curl -sSL https://github.com/psastras/sarif-rs/releases/download/shellcheck-sarif-v0.8.0/hadolint-sarif-x86_64-unknown-linux-gnu -o hadolint-sarif
+curl -sSL https://github.com/psastras/sarif-rs/releases/download/hadolint-sarif-v0.8.0/hadolint-sarif-x86_64-unknown-linux-gnu -o hadolint-sarif
 ```
 
 ### Fedora Linux


### PR DESCRIPTION
The URL for `hadolint-sarif` in the README has been corrected.

Incorrect URL:
```console
$ curl -o /dev/null -w '%{http_code}\n' -sL https://github.com/psastras/sarif-rs/releases/download/shellcheck-sarif-v0.8.0/hadolint-sarif-x86_64-unknown-linux-gnu
404
```

Correct URL:
```console
$ curl -o /dev/null -w '%{http_code}\n' -sL https://github.com/psastras/sarif-rs/releases/download/hadolint-sarif-v0.8.0/hadolint-sarif-x86_64-unknown-linux-gnu
200
```