### PR TITLE
Fix type for ThreadFlowLocation::importance

### DIFF
--- a/serde-sarif/build.rs
+++ b/serde-sarif/build.rs
@@ -110,6 +110,20 @@ fn process_token_stream(input: proc_macro2::TokenStream) -> syn::File {
         }
       }
 
+      // Rewrite ThreadFlowLocation::importance to use ThreadFlowLocationImportance
+      // instead of serde_json::Value.
+      // This is a workaround for schemafy's inability to produce appropriate
+      // exhaustive enums here.
+      if s.ident == "ThreadFlowLocation" {
+        if let syn::Fields::Named(fields) = &mut s.fields {
+          for field in fields.named.iter_mut() {
+            if field.ident.as_ref().unwrap() == "importance" {
+              field.ty = syn::parse_quote! { Option<ThreadFlowLocationImportance> };
+            }
+          }
+        }
+      }
+
       // for each struct field, if that field is Optional, set None
       // as the default value when using the builder
       (&mut s.fields).into_iter().for_each(|ref mut field| {

--- a/serde-sarif/src/sarif.rs
+++ b/serde-sarif/src/sarif.rs
@@ -145,7 +145,9 @@ pub enum SupressionStatus {
 }
 
 #[doc = "Specifies the importance of this location in understanding the code flow in which it occurs. The order from most to least important is \"essential\", \"important\", \"unimportant\". Default: \"important\"."]
-#[derive(Display, Debug, Serialize, Deserialize, EnumString)]
+#[derive(
+  Clone, Display, Debug, Serialize, Deserialize, EnumString, PartialEq,
+)]
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "camelCase")]
 pub enum ThreadFlowLocationImportance {


### PR DESCRIPTION
This is basically identical to #770, just for another API that had the wrong type.