### PR TITLE
Fix type of Result::baseline_state

### DIFF
--- a/serde-sarif/build.rs
+++ b/serde-sarif/build.rs
@@ -94,8 +94,8 @@ fn process_token_stream(input: proc_macro2::TokenStream) -> syn::File {
         }
       }
 
-      // Rewrite Result::kind and Result::level to use ResultKind and
-      // ResultLevel instead of serde_json::Value.
+      // Rewrite Result::kind, Result::level and Result::baseline_state to use
+      // ResultKind, ResultLevel and ResultBaselineState instead of serde_json::Value.
       // This is a workaround for schemafy's inability to produce appropriate
       // exhaustive enums here.
       if s.ident == "Result" {
@@ -105,6 +105,8 @@ fn process_token_stream(input: proc_macro2::TokenStream) -> syn::File {
               field.ty = syn::parse_quote! { Option<ResultKind> };
             } else if field.ident.as_ref().unwrap() == "level" {
               field.ty = syn::parse_quote! { Option<ResultLevel> };
+            } else if field.ident.as_ref().unwrap() == "baseline_state" {
+              field.ty = syn::parse_quote! { Option<ResultBaselineState> };
             }
           }
         }

--- a/serde-sarif/src/sarif.rs
+++ b/serde-sarif/src/sarif.rs
@@ -107,7 +107,9 @@ pub enum ResultLevel {
 }
 
 #[doc = "The state of a result relative to a baseline of a previous run."]
-#[derive(Display, Debug, Serialize, Deserialize, EnumString)]
+#[derive(
+  Clone, Copy, Display, Debug, Serialize, Deserialize, EnumString, PartialEq,
+)]
 #[serde(rename_all = "camelCase")]
 #[strum(serialize_all = "camelCase")]
 pub enum ResultBaselineState {


### PR DESCRIPTION
The [spec](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790912) uses a slightly different sentence compared two the other to enum fields but in my opinion it should still be the appropiate enum instead of any value.